### PR TITLE
parse: Don't use assembly code as data

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -1926,6 +1926,19 @@ static Node *primary(void) {
         node->ty = void_type;
       } else if (!strcmp(node->funcname, "asm")) {
         node->ty = int_type;
+        // The last argument is known to be verbatim code.
+        Node *asm_code = node->args;
+        if (asm_code) {
+          while (asm_code->next) {
+            asm_code = asm_code->next;
+          }
+          // The last argument to `asm` should not be considered an initializer.
+          asm_code->var->initializer = false;
+        }
+        else {
+          // Let's also error out on bogus `asm()` usage.
+          error_tok(tok, "assembly code missing");
+        }
       } else {
         warn_tok(node->tok, "implicit declaration of a function");
         node->ty = int_type;


### PR DESCRIPTION
Fixes #29

* * *

Hi! :wave: 

Not sure the solution is *correct*, but it works.

I'm not sure if the `text` section *should* fold down repeated uses of e.g. the same string in the code to a single instance. Currently it does not, but if it does, it would be necessary to ensure that some `asm(...)` string that coincides with an arbitrary string elsewhere does *not* get elided accidentally.

Feel free to suggest changes, though provide good hints :).