### PR TITLE
 codegen: Add -nostartfiles to drop the hardcoded prelude

### DIFF
--- a/src/chibi.h
+++ b/src/chibi.h
@@ -306,7 +306,15 @@ typedef struct {
 
 void varvara_argc_argv_hook(void);
 
-void codegen(Program *prog, bool do_opt, int devices_size, Device* devices, Device* console, void (*argc_argv_hook)(void));
+void codegen(
+  Program *prog,
+  bool do_opt,
+  bool emit_start,
+  int devices_size,
+  Device* devices,
+  Device* console,
+  void (*argc_argv_hook)(void)
+);
 
 //
 // optimize.c

--- a/src/main.c
+++ b/src/main.c
@@ -38,6 +38,17 @@ int main(int argc, char **argv) {
       do_opt = true;
     } else if (!strcmp("-O0", argv[i])) {
       do_opt = false;
+    } else if (!strcmp("-h", argv[i])) {
+      printf("Usage: %s [options] <file>\n", argv[0]);
+      printf(
+        "\n"
+        "  -h             Print this help\n"
+        "  -O             Same as -O1\n"
+        "  -O1            Apply simple optimizations\n"
+        "  -O0            Apply no optimizations (default)\n"
+        "\n"
+      );
+      exit(0);
     } else if (argv[i][0] == '-') {
       error("%s: unrecognized option \"%s\"", argv[0], argv[i]);
     } else if (!filename) {

--- a/src/main.c
+++ b/src/main.c
@@ -32,12 +32,15 @@ static char *read_file(char *path) {
 
 int main(int argc, char **argv) {
   bool do_opt = false;
+  bool emit_start = true;
 
   for (int i = 1; i < argc; i++) {
     if (!strcmp("-O", argv[i]) || !strcmp("-O1", argv[i])) {
       do_opt = true;
     } else if (!strcmp("-O0", argv[i])) {
       do_opt = false;
+    } else if (!strcmp("-nostartfiles", argv[i])) {
+      emit_start = false;
     } else if (!strcmp("-h", argv[i])) {
       printf("Usage: %s [options] <file>\n", argv[0]);
       printf(
@@ -46,6 +49,7 @@ int main(int argc, char **argv) {
         "  -O             Same as -O1\n"
         "  -O1            Apply simple optimizations\n"
         "  -O0            Apply no optimizations (default)\n"
+        "  -nostartfiles  Disable output of the default startup prelude\n"
         "\n"
       );
       exit(0);
@@ -93,7 +97,7 @@ int main(int argc, char **argv) {
     {"console", 0x10}, {"screen", 0x20}, {"audio1", 0x30},     {"audio2", 0x40},
     {"audio3", 0x50},  {"audio4", 0x60}, {"controller", 0x80}, {"mouse", 0x90},
   };
-  codegen(prog, do_opt, sizeof(devices) / sizeof(Device), devices, &devices[0],
+  codegen(prog, do_opt, emit_start, sizeof(devices) / sizeof(Device), devices, &devices[0],
     varvara_argc_argv_hook);
   fprintf(stderr, "codegen(): allocated %d bytes\n", total_alloc);
 


### PR DESCRIPTION
This is useful mainly if you desire to use your own "prelude" for
whatever purpose you may have.

This includes, but is not limited to, prepending a prelude that is aware
of the [metadata conventions](https://wiki.xxiivv.com/site/metadata.html).

Note that *at this point in time* it is not possible to trivially place
a prelude within the C code. The file always starts with `bss`, then `text`,
making things awkward at best.

It would be expected that the prelude is "bring your own" outside of
what this compiler produces.

* * *

I don't really like *just* adding yet another param to `codegen()`, but this was the trivial way to handle this.

*A* more proper way would be to fold all options, or codegen options, into a struct and provide that instead. This way adding options gets less verbose.

* * *

Tip: when reviewing [hide whitespace changes](https://github.com/lynn/chibicc/pull/35/files?w=1) to get a cleaner overview of the actual changes.

* * *

(Also adds a help section because we can.)