### PR TITLE
Implement four out of five suggested optimizations

### DIFF
--- a/src/chibi.h
+++ b/src/chibi.h
@@ -375,6 +375,7 @@ typedef enum {
   EOR2 = EOR | flag_2,
   SFT2 = SFT | flag_2,
 
+  ORAk = ORA | flag_k,
   STA2k = STA2 | flag_k,
   STH2kr = STH2 | flag_k | flag_r,
   POP2r = POP2 | flag_r,


### PR DESCRIPTION
Fix #27

The remaining suggestion requires understanding where a label point to so that it can be replaced by its literal equivalent. See #36.

* * *

Hopefully I didn't get anything wrong here.

I have verified the optimizations within `oneko-uxn`, and verified it works still.

The change isn't anything to write home about, but still interesting. `61073 bytes → 60980 bytes`

I suspect #36 might boil down to interesting numbers though.

* * *

(I had observed something "going wrong", but it was unrelated, and the optimizations of my wrong use of the semantics around the calling convention in `asm()` was at fault, and failing otherwisely without these additional optimizations. It would be wise to validate carefully.)