### PR TITLE
support assignment between structs

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -245,10 +245,33 @@ static void gen(Node *node, int depth) {
       load(node->ty);
     return;
   case ND_ASSIGN:
-    gen(node->rhs, depth);
-    fix_bool(node->ty);
-    gen_lval(node->lhs, depth + 2);
-    store(node->ty);
+    if (node->rhs->ty->kind == TY_STRUCT) {
+      int i = node->ty->size;
+      if (i % 2 == 1) {
+        i--;
+        gen_lval(node->rhs, depth);
+        emit_add(i);
+        op(LDA);
+        gen_lval(node->lhs, depth);
+        emit_add(i);
+        op(STA);
+      }
+      while (i > 0) {
+        i -= 2;
+        gen_lval(node->rhs, depth);
+        emit_add(i);
+        op(LDA2);
+        gen_lval(node->lhs, depth);
+        emit_add(i);
+        op(STA2);
+      }
+      lit2(0);
+    } else {
+      gen(node->rhs, depth);
+      fix_bool(node->ty);
+      gen_lval(node->lhs, depth + 2);
+      store(node->ty);
+    }
     return;
   case ND_TERNARY: {
     int seq = labelseq++;

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -40,6 +40,12 @@ static void gen_addr(Node *node, int depth) {
     gen_addr(node->lhs, depth);
     emit_add(node->member->offset);
     return;
+  case ND_ASSIGN:
+    if (node->ty->kind == TY_STRUCT) {
+      gen_addr(node->rhs, depth);
+      return;
+    }
+    /* fallthrough */
   default:
     error_tok(node->tok, "not an lvalue");
     return;

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -252,6 +252,8 @@ static void gen(Node *node, int depth) {
     return;
   case ND_ASSIGN:
     if (node->rhs->ty->kind == TY_STRUCT) {
+      gen(node->rhs, depth);
+      op(POP2);
       int i = node->ty->size;
       if (i % 2 == 1) {
         i--;

--- a/tests
+++ b/tests
@@ -720,6 +720,8 @@ void main() {
   assert(2, ({ struct {int a; int b;} x[2]={0,1,2,3}; x[1].a; }), "struct {int a; int b;} x[2]={0,1,2,3}; x[1].a;");
   assert(9, ({ struct {int a; int b; int c;} x = {2,3,4}, y = {0,0,0}; y = x; y.a + y.b + y.c; }),
               "struct {int a; int b; int c;} x = {2,3,4}, y = {0,0,0}; y = x; y.a + y.b + y.c;");
+  assert(2, ({ struct {char a; int b;} x={1,2}, y={0,0}; (y = x).b; }),
+              "struct {char a; int b;} x={1,2}, y={0,0}; (y = x).b;");
 
   assert(0, strcmp(g15, "foo"), "strcmp(g15, \"foo\")");
   assert(0, strcmp(g16[0], "foo"), "strcmp(g16[0], \"foo\")");

--- a/tests
+++ b/tests
@@ -718,6 +718,8 @@ void main() {
 
   assert(0, ({ struct {int a; int b;} x[2]={0,1,2,3}; x[0].a; }), "struct {int a; int b;} x[2]={0,1,2,3}; x[0].a;");
   assert(2, ({ struct {int a; int b;} x[2]={0,1,2,3}; x[1].a; }), "struct {int a; int b;} x[2]={0,1,2,3}; x[1].a;");
+  assert(9, ({ struct {int a; int b; int c;} x = {2,3,4}, y = {0,0,0}; y = x; y.a + y.b + y.c; }),
+              "struct {int a; int b; int c;} x = {2,3,4}, y = {0,0,0}; y = x; y.a + y.b + y.c;");
 
   assert(0, strcmp(g15, "foo"), "strcmp(g15, \"foo\")");
   assert(0, strcmp(g16[0], "foo"), "strcmp(g16[0], \"foo\")");

--- a/tests
+++ b/tests
@@ -722,6 +722,8 @@ void main() {
               "struct {int a; int b; int c;} x = {2,3,4}, y = {0,0,0}; y = x; y.a + y.b + y.c;");
   assert(2, ({ struct {char a; int b;} x={1,2}, y={0,0}; (y = x).b; }),
               "struct {char a; int b;} x={1,2}, y={0,0}; (y = x).b;");
+  assert(6, ({ struct {char a; int b;} x={1,2}, y={0,0}, z={0,0}; z = y = x; z.a + z.b + y.a + y.b; }),
+              "struct {char a; int b;} x={1,2}, y={0,0}, z={0,0}; z = y = x; z.a + z.b + y.a + y.b;");
 
   assert(0, strcmp(g15, "foo"), "strcmp(g15, \"foo\")");
   assert(0, strcmp(g16[0], "foo"), "strcmp(g16[0], \"foo\")");


### PR DESCRIPTION
```
struct {
  char a;
  int b;
} foo = {1, 2}, bar = {0, 0};
bar = foo; // bar is now {1, 2}
```

closes #25 